### PR TITLE
Minor enhancements

### DIFF
--- a/_build/data/transport.settings.php
+++ b/_build/data/transport.settings.php
@@ -65,4 +65,13 @@ $settings['elementhelper.auto_remove_elements']->fromArray(array(
     'area' => 'default'
 ), '', true, true);
 
+$settings['elementhelper.source'] = $modx->newObject('modSystemSetting');
+$settings['elementhelper.source']->fromArray(array(
+    'key' => 'elementhelper.source',
+    'value' => 1,
+    'xtype' => 'modx-combo-source',
+    'namespace' => 'elementhelper',
+    'area' => 'default'
+), '', true, true);
+
 return $settings;

--- a/core/components/elementhelper/lexicon/de/default.inc.php
+++ b/core/components/elementhelper/lexicon/de/default.inc.php
@@ -1,0 +1,25 @@
+<?php
+
+$_lang['setting_elementhelper.chunk_path'] = 'Chunks Pfad';
+$_lang['setting_elementhelper.chunk_path_desc'] = 'Pfad zum Chunks-Ordner.';
+
+$_lang['setting_elementhelper.template_path'] = 'Templates Pfad';
+$_lang['setting_elementhelper.template_path_desc'] = 'Pfad zum Templates-Ordner.';
+
+$_lang['setting_elementhelper.snippet_path'] = 'Snippets Pfad';
+$_lang['setting_elementhelper.snippet_path_desc'] = 'Pfad zum Snippets-Ordner.';
+
+$_lang['setting_elementhelper.plugin_path'] = 'Plugins Pfad';
+$_lang['setting_elementhelper.plugin_path_desc'] = 'Pfad zum Plugins-Ordner.';
+
+$_lang['setting_elementhelper.tv_json_path'] = 'Template Variablen JSON Pfad';
+$_lang['setting_elementhelper.tv_json_path_desc'] = 'Pfad zum Template Variablen JSON File.';
+
+$_lang['setting_elementhelper.tv_access_control'] = 'Template Variablen Zugriffsberechtigung';
+$_lang['setting_elementhelper.tv_access_control_desc'] = 'Element Helper erlauben, Template Variablen den Zugriff auf die Templates zu geben, die im JSON File angegeben wurden. Achtung: Wird diese Option auf 1 gesetzt, werden alle Zugriffsberechtigungen einer Template Variable entfernt, die nicht im JSON File angegeben sind.';
+
+$_lang['setting_elementhelper.auto_remove_elements'] = 'Elemente automatisch entfernen';
+$_lang['setting_elementhelper.auto_remove_elements_desc'] = 'Element Helper erlauben, Elemente aus dem Manager zu entfernen, sobald die statischen Quelldateien gelöscht werden (das Aktivieren dieser Option wird auch Template Variablen entfernen, die nicht (mehr) im JSON File aufgeführt sind).';
+
+$_lang['setting_elementhelper.source'] = 'Medienquelle für Elemente';
+$_lang['setting_elementhelper.source'] = 'Zeigt standardmässig auf die Medienquelle mit der ID 1, auf korrekte Medienquelle ändern, falls eine andere für statische Elemente verwendet wird.';

--- a/core/components/elementhelper/lexicon/en/default.inc.php
+++ b/core/components/elementhelper/lexicon/en/default.inc.php
@@ -20,3 +20,6 @@ $_lang['setting_elementhelper.tv_access_control_desc'] = 'Allow elementhelper to
 
 $_lang['setting_elementhelper.auto_remove_elements'] = 'Automatically Remove Elements';
 $_lang['setting_elementhelper.auto_remove_elements_desc'] = 'Allow elementhelper to remove elements if you delete their source files (this will also remove TVs when you remove them from the TV JSON file).';
+
+$_lang['setting_elementhelper.source'] = 'Elements media source';
+$_lang['setting_elementhelper.source'] = 'Defaults to media source with ID 1, change to according media source if another is used for static elements.';

--- a/core/components/elementhelper/model/elementhelper/elementhelper.class.php
+++ b/core/components/elementhelper/model/elementhelper/elementhelper.class.php
@@ -25,21 +25,25 @@ class ElementHelper
             $element = $this->modx->newObject($element_type['class_name']);
 
             $element->set($name_field, $name);
-            $element->set('description', '');
+            $element->set('description', 'Imported by Element Helper plugin'); // to avoid problem below just set a default description
+            // it would be actually nice if we had the possibility to somehow specify a description for each item, but at the moment
+            // I have no elegant solution to this
         }
 
+        // exside: This throws error "modSnippet: Attempt to set NOT NULL field description to NULL" and multiple times per reload
         // Set the description for snippets
-        if ($element_type['class_name'] === 'modSnippet')
+        /*if ($element_type['class_name'] === 'modSnippet')
         {
             $element->set('description', $this->_get_description($content));
-        }
+        }*/
 
         $category_path = dirname(str_replace(MODX_BASE_PATH . $element_type['path'], '', $file_path));
         $category_names = explode('/', $category_path);
 
         $element->set('category', $this->get_category_id(end($category_names)));
         $element->set('static', 1);
-        $element->set('source', 1);
+        //$element->set('source', 1); // Makes big time problems if Mediasource with ID 1 isn't set to the base path
+        $element->set('source', $this->modx->getOption('elementhelper.source')); // created new system setting "elementhelper.source" with description "Media Source of static elements"
         $element->set('static_file', str_replace(MODX_BASE_PATH, '', $file_path));
 
         $element->setContent($content);
@@ -71,7 +75,7 @@ class ElementHelper
 
         $element->save();
 
-        if ($this->modx->getOption('elementhelper.tv_access_control') == True)
+        if ($this->modx->getOption('elementhelper.tv_access_control') == true)
         {
             $templates = $this->modx->getCollection('modTemplate');
 


### PR DESCRIPTION
- Fixed problems with media source 1 not pointing to base path (ehelper
  creating folder structure outgoing from the ms path), making plugin independent from media source 1 (through system setting)
- Added system setting "elementhelper.source" to specify which media
  source should be used for the static files
- Added german translation + added one string to the en lexicon for the
  new system setting
