### PR TITLE
Minor enhancements

### DIFF
--- a/_build/data/transport.settings.php
+++ b/_build/data/transport.settings.php
@@ -74,4 +74,13 @@ $settings['elementhelper.source']->fromArray(array(
     'area' => 'default'
 ), '', true, true);
 
+$settings['elementhelper.descriptionkey'] = $modx->newObject('modSystemSetting');
+$settings['elementhelper.descriptionkey']->fromArray(array(
+    'key' => 'elementhelper.descriptionkey',
+    'value' => '@Description',
+    'xtype' => 'textfield',
+    'namespace' => 'elementhelper',
+    'area' => 'default'
+), '', true, true);
+
 return $settings;

--- a/core/components/elementhelper/lexicon/de/default.inc.php
+++ b/core/components/elementhelper/lexicon/de/default.inc.php
@@ -23,3 +23,6 @@ $_lang['setting_elementhelper.auto_remove_elements_desc'] = 'Element Helper erla
 
 $_lang['setting_elementhelper.source'] = 'Medienquelle für Elemente';
 $_lang['setting_elementhelper.source'] = 'Zeigt standardmässig auf die Medienquelle mit der ID 1, auf korrekte Medienquelle ändern, falls eine andere für statische Elemente verwendet wird.';
+
+$_lang['setting_elementhelper.descriptionkey'] = 'Description String';
+$_lang['setting_elementhelper.descriptionkey'] = 'String um Elementbeschreibung im ersten Kommentarblock eines Elements zu identifizieren. Standard ist @Description';

--- a/core/components/elementhelper/lexicon/en/default.inc.php
+++ b/core/components/elementhelper/lexicon/en/default.inc.php
@@ -23,3 +23,6 @@ $_lang['setting_elementhelper.auto_remove_elements_desc'] = 'Allow elementhelper
 
 $_lang['setting_elementhelper.source'] = 'Elements media source';
 $_lang['setting_elementhelper.source'] = 'Defaults to media source with ID 1, change to according media source if another is used for static elements.';
+
+$_lang['setting_elementhelper.descriptionkey'] = 'Description key';
+$_lang['setting_elementhelper.descriptionkey'] = 'String to identify description information for elements inside the opening comment block, defaults to @Description.';

--- a/core/components/elementhelper/model/elementhelper/elementhelper.class.php
+++ b/core/components/elementhelper/model/elementhelper/elementhelper.class.php
@@ -23,31 +23,21 @@ class ElementHelper
         if (!isset($element))
         {
             $element = $this->modx->newObject($element_type['class_name']);
-
+            
             $element->set($name_field, $name);
-            $element->set('description', 'Imported by Element Helper plugin'); // to avoid problem below just set a default description
-            // it would be actually nice if we had the possibility to somehow specify a description for each item, but at the moment
-            // I have no elegant solution to this
         }
-
-        // This throws error "modSnippet: Attempt to set NOT NULL field description to NULL" and multiple times per reload
-        // Set the description for snippets
-        /*if ($element_type['class_name'] === 'modSnippet')
-        {
-            $element->set('description', $this->_get_description($content));
-        }*/
 
         $category_path = dirname(str_replace(MODX_BASE_PATH . $element_type['path'], '', $file_path));
         $category_names = explode('/', $category_path);
+        $description = $this->_get_description($content) != '' ? $this->_get_description($content) : 'Imported by Element Helper Plugin';
 
         $element->set('category', $this->get_category_id(end($category_names)));
+        $element->set('description', $description);
         $element->set('static', 1);
-        //$element->set('source', 1); // makes problems if Mediasource with ID 1 isn't set to the base path
-        $element->set('source', $this->modx->getOption('elementhelper.source')); // created new system setting "elementhelper.source"
+        $element->set('source', $this->modx->getOption('elementhelper.source')); // check content of system setting "elementhelper.source"
         // get the base path of the defined media source to determine the right path to set for the static file
         $source = $this->modx->getObject('sources.modMediaSource', array('id' => $element->get('source')));
-        $source->initialize(); // unfortunately necessary, media source getters will not work without this
-        //$element->set('static_file', str_replace(MODX_BASE_PATH, '', $file_path));
+        $source->initialize(); // unfortunately necessary, getters will not work without this
         $element->set('static_file', str_replace($source->getBasePath(), '', $file_path));
 
         $element->setContent($content);
@@ -175,7 +165,7 @@ class ElementHelper
             
             foreach($comment_lines as $comment_line)
             {
-                if (preg_match('/@Description (.*)/', $comment_line, $match))
+                if (preg_match('/' . $this->modx->getOption('elementhelper.descriptionkey') . ' (.*)/', $comment_line, $match)) // get string to search for description from system setting
                 {
                     $description = $match[1];
                 }


### PR DESCRIPTION
- Fixed problems with media source 1 not pointing to base path (ehelper creating folder structure outgoing from the ms path), making plugin independent from media source 1 (through system setting)
- Added system setting "elementhelper.source" to specify which media source should be used for the static files
- Added german translation + added one string to the en lexicon for the new system setting
