### PR TITLE
Don't import .DS_Store files - OSX folder metadata files.

### DIFF
--- a/core/components/elementhelper/elements/plugins/plugin.elementhelper.php
+++ b/core/components/elementhelper/elements/plugins/plugin.elementhelper.php
@@ -65,7 +65,7 @@ if ($modx->user->isMember($usergroups))
             // Get a list of files from the element types directory
             while (($item = readdir($directory)) !== false)
             {   
-                if ($item !== '.' && $item !== '..')
+                if ($item !== '.' && $item !== '..' && $item != '.DS_Store')
                 {
                     $item_path = $directory_path . $item;
 


### PR DESCRIPTION
When running on the Mac, erroneous elements are created for .DS_Store files. It's not possible to remove these on OSX, they're there for storing folder metadata.
